### PR TITLE
Add get_keys()

### DIFF
--- a/firebase_remoteconfig/api/firebase.script_api
+++ b/firebase_remoteconfig/api/firebase.script_api
@@ -80,6 +80,15 @@
       type: string
       desc: The value
 
+  - name: remoteconfig.get_keys
+    type: function
+    desc: Gets the set of all keys. (Official docs https://firebase.google.com/docs/reference/cpp/class/firebase/remote-config/remote-config#getkeys)
+
+    return:
+    - name: keys
+      type: table
+      desc: An array of strings representing parameter keys
+
   - name: remoteconfig.set_defaults
     type: function
     desc: Sets the default values. (Official docs https://firebase.google.com/docs/reference/cpp/class/firebase/remote-config/remote-config#setdefaults)

--- a/firebase_remoteconfig/src/firebase_remoteconfig.cpp
+++ b/firebase_remoteconfig/src/firebase_remoteconfig.cpp
@@ -217,6 +217,26 @@ static int FirebaseRemoteConfig_GetString(lua_State* L) {
 	return 1;
 }
 
+static int FirebaseRemoteConfig_GetKeys(lua_State* L) {
+	DM_LUA_STACK_CHECK(L, 1);
+	if (!g_FirebaseRemoteConfig_Initialized)
+	{
+		dmLogWarning("Firebase Remote Config has not been initialized! Make sure to call firebase.remoteconfig.init().");
+		return 0;
+	}
+	std::vector<std::string> keys = FirebaseRemoteConfig_GetInstance()->GetKeys();
+
+	lua_newtable(L);
+	int numKeys = keys.size();
+	for (int idx = 0; idx < numKeys; ++idx)
+	{
+		lua_pushstring(L, keys[idx].c_str());  
+		lua_rawseti(L, -2, idx + 1);
+	}
+
+	return 1;
+}
+
 static int FirebaseRemoteConfig_SetDefaults(lua_State* L) {
 	DM_LUA_STACK_CHECK(L, 0);
 	if (!g_FirebaseRemoteConfig_Initialized)
@@ -326,6 +346,7 @@ static void LuaInit(lua_State* L) {
 	lua_pushtablestringfunction(L, "get_data", FirebaseRemoteConfig_GetData);
 	lua_pushtablestringfunction(L, "get_number", FirebaseRemoteConfig_GetNumber);
 	lua_pushtablestringfunction(L, "get_string", FirebaseRemoteConfig_GetString);
+	lua_pushtablestringfunction(L, "get_keys", FirebaseRemoteConfig_GetKeys);
 
 	lua_pushtablestringfunction(L, "fetch", FirebaseRemoteConfig_Fetch);
 	lua_pushtablestringfunction(L, "activate", FirebaseRemoteConfig_Activate);


### PR DESCRIPTION
It can be useful to know which keys exist in the remote config, this change exposes the GetKeys() function from the C++ API.